### PR TITLE
Allow Admin Role Updates by Email & Decouple Company Creation Flow

### DIFF
--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/config/security/JwtProvider.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/config/security/JwtProvider.java
@@ -42,7 +42,6 @@ public class JwtProvider {
                 .claim("name", user.getFirstName())
                 .claim("lastName", user.getLastName())
                 .claim("email", user.getEmail())
-                .claim("location", user.getLocation())
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
     }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/config/security/SecurityConfig.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/config/security/SecurityConfig.java
@@ -77,6 +77,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**"
                         ).permitAll()
 
+                        .requestMatchers(HttpMethod.PUT, "/users/role").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/fumigation-applications").hasRole("CLIENT")
                         .requestMatchers(HttpMethod.PUT, "/fumigations/{id}/status").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/fumigation-applications/{id}").hasAnyRole("CLIENT", "ADMIN")

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/controller/UserRestController.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/controller/UserRestController.java
@@ -14,8 +14,15 @@ public class UserRestController {
     private final UserService userService;
 
     @PostMapping("/auth/register")
-    public ResponseEntity<UserRegistrationResponseDTO> registerUser(@RequestBody @Valid UserRegistrationRequestDTO user){
+    public ResponseEntity<UserRegistrationResponseDTO> registerUser(
+            @RequestBody @Valid UserRegistrationRequestDTO user){
         return new ResponseEntity<>(userService.registerUser(user), HttpStatus.CREATED);
+    }
+
+    @PostMapping("/auth/profile-setup")
+    public void completeUserInfo(
+            @RequestBody @Valid UserProfileSetUpRequestDTO user){
+        userService.completeUserInfo(user);
     }
 
     @PostMapping("/auth/login")

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/controller/UserRestController.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/controller/UserRestController.java
@@ -34,4 +34,9 @@ public class UserRestController {
     public UserDTO getUserInfo () {
         return userService.getUserInfo();
     }
+
+    @PutMapping ("/users/role")
+    public void updateUsersRole(@RequestBody @Valid UserUpdateRoleDTO userUpdateRoleDTO) {
+        userService.updateUsersRole(userUpdateRoleDTO);
+    }
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/CompanyCreationDTO.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/CompanyCreationDTO.java
@@ -1,0 +1,25 @@
+package com.anecacao.api.auth.data.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class CompanyCreationDTO {
+    @NotBlank(message = "Company Name is required")
+    private String companyName;
+
+    @NotBlank(message = "Business Name is required")
+    private String businessName;
+
+    @NotBlank(message = "Phone Number is required")
+    @Pattern(regexp = "^\\d{10}$", message = "Phone number must be 10 digits")
+    private String phoneNumber;
+
+    @NotBlank(message = "RUC is required")
+    @Pattern(regexp = "^\\d{13}$", message = "RUC must be 13 digits")
+    private String ruc;
+
+    @NotBlank(message = "Address is required")
+    private String address;
+}

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserDTO.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserDTO.java
@@ -1,5 +1,6 @@
 package com.anecacao.api.auth.data.dto;
 
+import com.anecacao.api.request.creation.data.dto.response.CompanyResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -20,7 +21,7 @@ public class UserDTO {
 
     private String email;
 
-    private String location;
-
     private Set<RoleDTO> roles;
+
+    private Set<CompanyResponseDTO> companies;
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserProfileSetUpRequestDTO.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserProfileSetUpRequestDTO.java
@@ -1,0 +1,22 @@
+package com.anecacao.api.auth.data.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class UserProfileSetUpRequestDTO {
+    @NotBlank(message = "National ID is required")
+    @Pattern(regexp = "^\\d{10}$", message = "National ID must be 10 digits")
+    private String nationalId;
+
+    @JsonFormat(pattern = "dd-MM-yyyy")
+    private LocalDate birthday;
+
+    @NotNull
+    private CompanyCreationDTO company;
+}

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserRegistrationRequestDTO.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserRegistrationRequestDTO.java
@@ -1,19 +1,12 @@
 package com.anecacao.api.auth.data.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
-import java.time.LocalDate;
-
 @Data
 public class UserRegistrationRequestDTO {
-    @NotBlank(message = "National ID is required")
-    @Pattern(regexp = "^\\d{10}$", message = "National ID must be 10 digits")
-    private String nationalId;
-
     @NotBlank(message = "First name is required")
     private String firstName;
 
@@ -29,9 +22,4 @@ public class UserRegistrationRequestDTO {
             message = "Password must be at least 8 characters, with upper, lower case and a number"
     )
     private String password;
-
-    private String location;
-
-    @JsonFormat(pattern = "dd-MM-yyyy")
-    private LocalDate birthday;
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserRegistrationResponseDTO.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserRegistrationResponseDTO.java
@@ -1,11 +1,9 @@
 package com.anecacao.api.auth.data.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Data
@@ -14,18 +12,11 @@ import java.util.List;
 public class UserRegistrationResponseDTO {
     private Long id;
 
-    private String nationalId;
-
     private String firstName;
 
     private String lastName;
 
     private String email;
-
-    private String location;
-
-    @JsonFormat(pattern = "dd-MM-yyyy")
-    private LocalDate birthday;
 
     private List<RoleDTO> roles;
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserUpdateRoleDTO.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/dto/UserUpdateRoleDTO.java
@@ -1,0 +1,10 @@
+package com.anecacao.api.auth.data.dto;
+
+import jakarta.validation.constraints.Email;
+import lombok.Data;
+
+@Data
+public class UserUpdateRoleDTO {
+    @Email
+    private String email;
+}

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/entity/RoleName.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/entity/RoleName.java
@@ -2,5 +2,6 @@ package com.anecacao.api.auth.data.entity;
 
 public enum RoleName {
     ROLE_CLIENT,
-    ROLE_ADMIN
+    ROLE_ADMIN,
+    ROLE_TECHNICIAN
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/entity/User.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/entity/User.java
@@ -27,7 +27,6 @@ public class User {
     @Column(unique = true)
     private String email;
 
-    private String location;
     private LocalDate birthday;
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/repository/UserRepository.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/data/repository/UserRepository.java
@@ -9,11 +9,9 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository <User, Long> {
-    Optional<User> findByNationalId (String username);
+    boolean existsByNationalIdAndIdNot(String nationalId, Long userId);
 
-    Boolean existsUserByNationalId (String username);
-
-    Boolean existsUserByEmail (String email);
+    boolean existsUserByEmail (String email);
 
     @EntityGraph(attributePaths = "roles")
     Optional<User> findByEmail(String email);

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/exception/CompanyAlreadyExistsException.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/exception/CompanyAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.anecacao.api.auth.domain.exception;
+
+public class CompanyAlreadyExistsException extends RuntimeException {
+    public CompanyAlreadyExistsException() {
+        super("RUC already in use");
+    }
+}

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/exception/IllegalRoleChangeException.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/exception/IllegalRoleChangeException.java
@@ -1,0 +1,7 @@
+package com.anecacao.api.auth.domain.exception;
+
+public class IllegalRoleChangeException extends RuntimeException {
+    public IllegalRoleChangeException() {
+        super("Admins cannot change their own role");
+    }
+}

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/service/UserService.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/service/UserService.java
@@ -16,4 +16,6 @@ public interface UserService {
     User getUserReferenceById (String token);
   
     boolean hasRole(String userId, RoleName roleName);
+
+    void updateUsersRole(UserUpdateRoleDTO userUpdateRoleDTO);
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/service/UserService.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/service/UserService.java
@@ -7,6 +7,8 @@ import com.anecacao.api.auth.data.entity.User;
 public interface UserService {
     UserRegistrationResponseDTO registerUser(UserRegistrationRequestDTO userRequestDTO);
 
+    void completeUserInfo(UserProfileSetUpRequestDTO User);
+
     UserLoginResponseDTO loginUser (UserLoginRequestDTO userLoginRequestDTO);
 
     UserDTO getUserInfo();

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/service/impl/UserServiceImpl.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/service/impl/UserServiceImpl.java
@@ -105,6 +105,22 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public void updateUsersRole(UserUpdateRoleDTO userUpdateRoleDTO) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        User user = userRepository.findByEmail(userUpdateRoleDTO.getEmail())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found."));
+
+        if (userUpdateRoleDTO.getEmail().equals(email)) throw new IllegalRoleChangeException();
+
+        Role role = roleRepository.findByName(RoleName.ROLE_TECHNICIAN)
+                .orElseThrow(() -> new RuntimeException("Role not found."));
+
+        user.getRoles().add(role);
+        userRepository.save(user);
+    }
+
+    @Override
     public User getUserReferenceById (String token) {
         jwtProvider.validateToken(token);
         return userRepository.getReferenceById(jwtProvider.getUserIdFromJWT(token));

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/service/impl/UserServiceImpl.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/auth/domain/service/impl/UserServiceImpl.java
@@ -8,12 +8,12 @@ import com.anecacao.api.auth.data.entity.User;
 import com.anecacao.api.auth.data.mapper.UserMapper;
 import com.anecacao.api.auth.data.repository.RoleRepository;
 import com.anecacao.api.auth.data.repository.UserRepository;
-import com.anecacao.api.auth.domain.exception.RoleNotFoundException;
-import com.anecacao.api.auth.domain.exception.UserAlreadyExistsException;
-import com.anecacao.api.auth.domain.exception.UserNotFoundException;
+import com.anecacao.api.auth.domain.exception.*;
 import com.anecacao.api.auth.domain.service.UserPasswordService;
 import com.anecacao.api.auth.domain.service.UserService;
 
+import com.anecacao.api.request.creation.data.entity.Company;
+import com.anecacao.api.request.creation.domain.service.CompanyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -32,6 +32,7 @@ public class UserServiceImpl implements UserService {
     private final RoleRepository roleRepository;
     private final UserMapper userMapper;
     private final UserPasswordService userPasswordService;
+    private final CompanyService companyService;
     private final JwtProvider jwtProvider;
 
     @Override
@@ -49,6 +50,30 @@ public class UserServiceImpl implements UserService {
         userPasswordService.savePassword(newUser, userRequestDTO.getPassword());
 
         return userMapper.userToUserRegistrationResponseDTO(newUser);
+    }
+
+    @Override
+    public void completeUserInfo(UserProfileSetUpRequestDTO request) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException(email));
+
+        if (userRepository.existsByNationalIdAndIdNot(request.getNationalId(), user.getId())) {
+            throw new UserAlreadyExistsException();
+        }
+
+        if (companyService.existsByRuc(request.getCompany().getRuc())) {
+            throw new CompanyAlreadyExistsException();
+        }
+
+        user.setNationalId(request.getNationalId());
+        user.setBirthday(request.getBirthday());
+
+        Company company = companyService.createNewCompany(request.getCompany(), user);
+
+        user.getCompanies().add(company);
+
+        userRepository.save(user);
     }
 
     @Override
@@ -92,10 +117,7 @@ public class UserServiceImpl implements UserService {
     }
 
     private boolean areUserCredentialsAvailable(UserRegistrationRequestDTO userRequestDTO){
-        boolean nationalIdIsAvailable = !userRepository.existsUserByNationalId(userRequestDTO.getNationalId());
-        boolean emailIsAvailable = !userRepository.existsUserByEmail(userRequestDTO.getEmail());
-
-        return nationalIdIsAvailable && emailIsAvailable;
+        return !userRepository.existsUserByEmail(userRequestDTO.getEmail());
     }
 
     @Override

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/common/config/GlobalExceptionHandler.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/common/config/GlobalExceptionHandler.java
@@ -1,16 +1,13 @@
 package com.anecacao.api.common.config;
 
 import com.anecacao.api.auth.data.dto.ErrorResponseDTO;
-import com.anecacao.api.auth.domain.exception.RoleNotFoundException;
-import com.anecacao.api.auth.domain.exception.UserAlreadyExistsException;
-import com.anecacao.api.auth.domain.exception.UserNotFoundException;
+import com.anecacao.api.auth.domain.exception.*;
 import com.anecacao.api.request.creation.domain.exception.CompanyNotFoundException;
 import com.anecacao.api.request.creation.domain.exception.FumigationNotFoundException;
 import com.anecacao.api.request.creation.domain.exception.FumigationValidationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.anecacao.api.request.creation.domain.exception.FumigationApplicationNotFoundException;
-import com.anecacao.api.auth.domain.exception.UnauthorizedAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -117,6 +114,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(FumigationApplicationNotFoundException.class)
     public ResponseEntity<ErrorResponseDTO> handleFumigationApplicationNotFoundException(FumigationApplicationNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(buildResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalRoleChangeException.class)
+    public ResponseEntity<ErrorResponseDTO> handleIllegalRoleChangeException(IllegalRoleChangeException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(buildResponse(ex.getMessage()));
     }
 
     private ErrorResponseDTO buildResponse (String message) {

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/repository/CompanyRepository.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/repository/CompanyRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface CompanyRepository extends JpaRepository<Company, Long> {
     Optional<Company> findByIdAndLegalRepresentative(Long companyId, User legalRepresentative);
+
+    boolean existsByRuc(String ruc);
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/domain/service/CompanyService.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/domain/service/CompanyService.java
@@ -1,8 +1,13 @@
 package com.anecacao.api.request.creation.domain.service;
 
+import com.anecacao.api.auth.data.dto.CompanyCreationDTO;
 import com.anecacao.api.auth.data.entity.User;
 import com.anecacao.api.request.creation.data.entity.Company;
 
 public interface CompanyService {
     Company getCompanyOwnedByLegalRepresentative(Long companyId, User user);
+
+    boolean existsByRuc (String ruc);
+
+    Company createNewCompany(CompanyCreationDTO company, User user);
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/domain/service/impl/CompanyServiceImpl.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/domain/service/impl/CompanyServiceImpl.java
@@ -1,5 +1,6 @@
 package com.anecacao.api.request.creation.domain.service.impl;
 
+import com.anecacao.api.auth.data.dto.CompanyCreationDTO;
 import com.anecacao.api.auth.data.entity.User;
 import com.anecacao.api.request.creation.data.entity.Company;
 import com.anecacao.api.request.creation.data.repository.CompanyRepository;
@@ -18,5 +19,22 @@ public class CompanyServiceImpl implements CompanyService {
         return repository
                 .findByIdAndLegalRepresentative(companyId, user)
                 .orElseThrow(() -> new CompanyNotFoundException(companyId, user.getId()));
+    }
+
+    @Override
+    public boolean existsByRuc(String ruc) {
+        return repository.existsByRuc(ruc);
+    }
+
+    @Override
+    public Company createNewCompany(CompanyCreationDTO companyDTO, User user) {
+        Company company = new Company();
+        company.setName(companyDTO.getCompanyName());
+        company.setBusinessName(companyDTO.getBusinessName());
+        company.setPhoneNumber(companyDTO.getPhoneNumber());
+        company.setRuc(companyDTO.getRuc());
+        company.setAddress(companyDTO.getAddress());
+        company.setLegalRepresentative(user);
+        return company;
     }
 }


### PR DESCRIPTION
#### Users

* **Added endpoint** to allow admins to update a user's role using their email.
* **Validation added**: admins are now restricted from modifying their own role to prevent privilege downgrading.
* Created `UpdateUserRoleRequestDTO` for clean input handling.
* Added custom exception: `SelfRoleModificationNotAllowedException`.

#### Refactors

* Restructured `auth`-related DTOs and services to **decouple company setup** from user registration logic.
* Cleaned up user-related DTOs to align with the updated flow.
* Introduced `CompanyAlreadyExistsException` for better error signaling.