### PR TITLE
Fix/fumigation report

### DIFF
--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/data/dto/FumigationReportDTO.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/data/dto/FumigationReportDTO.java
@@ -1,6 +1,5 @@
 package com.anecacao.api.reporting.data.dto;
 
-import com.anecacao.api.reporting.data.entity.IndustrialSafetyConditions;
 import com.anecacao.api.reporting.data.entity.EnvironmentalConditions;
 import com.anecacao.api.request.creation.data.entity.Dimensions;
 import com.anecacao.api.reporting.data.entity.Supply;
@@ -17,6 +16,9 @@ import java.util.List;
 public class FumigationReportDTO {
     @NotNull(message = "Fumigation ID must not be null")
     private Long id;
+
+    @NotNull(message = "Supervisor must not be null")
+    private String supervisor;
 
     @NotNull(message = "Location must not be null")
     private String location;

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/data/dto/response/FumigationReportResponseDTO.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/data/dto/response/FumigationReportResponseDTO.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Data
 public class FumigationReportResponseDTO {
     private Long id;
+    private String supervisor;
     private String location;
     private LocalDate date;
     private LocalTime startTime;

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/data/entity/FumigationReport.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/data/entity/FumigationReport.java
@@ -44,6 +44,8 @@ public class FumigationReport {
     @Column(nullable = false)
     private Dimensions dimensions;
 
+    private String supervisor;
+
     private String observations;
 
     @ManyToMany

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/domain/exception/InvalidFumigationStatusException.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/domain/exception/InvalidFumigationStatusException.java
@@ -1,7 +1,9 @@
 package com.anecacao.api.reporting.domain.exception;
 
+import com.anecacao.api.request.creation.data.entity.Status;
+
 public class InvalidFumigationStatusException extends RuntimeException {
-    public InvalidFumigationStatusException(Long id) {
-        super ("Fumigation with ID " + id + " cannot be reported because it is not in an approved or failed state.");
+    public InvalidFumigationStatusException(Long id, Status status) {
+        super ("Fumigation with ID " + id + " cannot be reported because it is not in an " + status + " or failed state.");
     }
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/domain/service/impl/ReportsServiceImpl.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/domain/service/impl/ReportsServiceImpl.java
@@ -45,7 +45,7 @@ public class ReportsServiceImpl implements ReportsService {
     @Transactional
     @Override
     public MessageDTO createFumigationReport(FumigationReportDTO reportDTO) {
-        Fumigation fumigation = getValidFumigation(reportDTO.getId());
+        Fumigation fumigation = getValidFumigation(reportDTO.getId(), Status.APPROVED);
 
         checkTechniciansRole(reportDTO.getTechnicians());
 
@@ -59,7 +59,7 @@ public class ReportsServiceImpl implements ReportsService {
 
     @Override
     public MessageDTO createCleanupReport(CleanupReportDTO reportDTO) {
-        Fumigation fumigation = getValidFumigation(reportDTO.getId());
+        Fumigation fumigation = getValidFumigation(reportDTO.getId(), Status.FUMIGATED);
 
         checkTechniciansRole(reportDTO.getTechnicians());
 
@@ -85,12 +85,12 @@ public class ReportsServiceImpl implements ReportsService {
         return conditions;
     }
 
-    private Fumigation getValidFumigation(Long id) {
+    private Fumigation getValidFumigation(Long id, Status status) {
         Fumigation fumigation = fumigationRepository.findById(id)
                 .orElseThrow(() -> new FumigationNotFoundException(id));
 
-        if (!fumigation.getStatus().equals(Status.FUMIGATED) && !fumigation.getStatus().equals(Status.FAILED)) {
-            throw new InvalidFumigationStatusException(id);
+        if (!fumigation.getStatus().equals(status) && !fumigation.getStatus().equals(Status.FAILED)) {
+            throw new InvalidFumigationStatusException(id, status);
         }
 
         return fumigation;

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/domain/service/impl/ReportsServiceImpl.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/reporting/domain/service/impl/ReportsServiceImpl.java
@@ -54,7 +54,7 @@ public class ReportsServiceImpl implements ReportsService {
 
         IndustrialSafetyConditionsDTO conditionsDTO = reportDTO.getIndustrialSafetyConditions();
 
-        return processReportAndUpdateStatus(mapper.toConditionEntity(conditionsDTO), fumigation, report, true);
+        return processReportAndUpdateStatus(mapper.toConditionEntity(conditionsDTO), fumigation, report,Status.FUMIGATED, true);
     }
 
     @Override
@@ -65,7 +65,7 @@ public class ReportsServiceImpl implements ReportsService {
 
         CleanupReport report = getOrCreateCleanupReport(reportDTO, fumigation);
 
-        return processReportAndUpdateStatus(reportDTO.getIndustrialSafetyConditions(), fumigation, report, false);
+        return processReportAndUpdateStatus(reportDTO.getIndustrialSafetyConditions(), fumigation, report, Status.FINISHED,false);
     }
 
     private void checkTechniciansRole(List<SimpleUserDTO> technicians) {
@@ -89,7 +89,7 @@ public class ReportsServiceImpl implements ReportsService {
         Fumigation fumigation = fumigationRepository.findById(id)
                 .orElseThrow(() -> new FumigationNotFoundException(id));
 
-        if (!fumigation.getStatus().equals(Status.APPROVED) && !fumigation.getStatus().equals(Status.FAILED)) {
+        if (!fumigation.getStatus().equals(Status.FUMIGATED) && !fumigation.getStatus().equals(Status.FAILED)) {
             throw new InvalidFumigationStatusException(id);
         }
 
@@ -129,11 +129,12 @@ public class ReportsServiceImpl implements ReportsService {
     private MessageDTO processReportAndUpdateStatus(IndustrialSafetyConditions conditions,
                                                     Fumigation fumigation,
                                                     Object report,
+                                                    Status status,
                                                     boolean isFumigationReport) {
         if (conditions.hasAnyDanger()) {
             fumigation.setStatus(Status.FAILED);
         } else {
-            fumigation.setStatus(Status.APPROVED);
+            fumigation.setStatus(status);
         }
 
         fumigationRepository.save(fumigation);

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/entity/Fumigation.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/entity/Fumigation.java
@@ -16,6 +16,8 @@ public class Fumigation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String supervisor;
+
     @Column(nullable = false)
     private String lotNumber;
 

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/entity/Fumigation.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/entity/Fumigation.java
@@ -16,8 +16,6 @@ public class Fumigation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String supervisor;
-
     @Column(nullable = false)
     private String lotNumber;
 

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/entity/Status.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/entity/Status.java
@@ -4,6 +4,7 @@ public enum Status {
     APPROVED,
     PENDING,
     REJECTED,
+    FUMIGATED,
     FINISHED,
     FAILED
 }

--- a/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/mapper/FumigationApplicationMapper.java
+++ b/Backend/anecacao_api/src/main/java/com/anecacao/api/request/creation/data/mapper/FumigationApplicationMapper.java
@@ -61,10 +61,12 @@ public interface FumigationApplicationMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "environmentalConditions", source = "environmentalConditions")
+    @Mapping(target = "supervisor", source = "supervisor")
     FumigationReport toFumigationReport (FumigationReportDTO dto);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "environmentalConditions", source = "environmentalConditions")
+    @Mapping(target = "supervisor", source = "supervisor")
     void updateFumigationReportFromDTO(FumigationReportDTO dto, @MappingTarget FumigationReport report);
 
     @Mapping(target = "id", ignore = true)


### PR DESCRIPTION
#### Fumigation Reports

* **Fixed mapping** of `supervisor` field from `FumigationReportDTO` to `FumigationReport` entity to ensure it is correctly persisted.
* **Added new `FUMIGATED` status** to the fumigation process workflow. Closes #28.
* **Added `supervisor` field** to fumigation reports at both the entity and DTO levels, covering the **POST** operation. The **GET** implementation will be handled in a separate PR by another teammate. Partially addresses #27.